### PR TITLE
feat: Add GitHub Actions workflow to build Android APK

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,36 @@
+name: Android Build
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of building the Android application.

The workflow is defined in `.github/workflows/android-build.yml` and includes the following steps:
- Checks out the source code
- Sets up the Java 11 environment
- Grants execute permissions to the Gradle wrapper
- Builds the debug APK using Gradle
- Uploads the generated APK as a build artifact

The workflow is triggered on pushes to the `main` branch and can also be run manually.